### PR TITLE
Fix default max_seq_len from 200 to 512

### DIFF
--- a/model/LMConfig.py
+++ b/model/LMConfig.py
@@ -15,7 +15,7 @@ class LMConfig(PretrainedConfig):
             hidden_dim: int = None,
             multiple_of: int = 64,
             norm_eps: float = 1e-5,
-            max_seq_len: int = 200,
+            max_seq_len: int = 512,
             dropout: float = 0.0,
             flash_attn: bool = True,
             image_special_token: str = '<' * 25 + '>' * 25,


### PR DESCRIPTION
#13 As mentioned in the issue, I think we can change the default one to 512, so people can quickly run it without extra errors.